### PR TITLE
fix: add instructions and setup script to Anchor programs

### DIFF
--- a/templates/template-next-tailwind-basic/package.json
+++ b/templates/template-next-tailwind-basic/package.json
@@ -12,6 +12,12 @@
     "wallet-ui"
   ],
   "create-solana-dapp": {
+    "instructions": [
+      "To configure the Anchor deployment keypair, run this:",
+      "+{pm} run setup",
+      "Run Anchor commands:",
+      "+{pm} run anchor build | test | localnet | deploy"
+    ],
     "rename": {
       "basic": {
         "to": "{{name}}",
@@ -44,6 +50,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "next lint",
+    "setup": "npm run anchor keys sync && npm run codama:js",
     "start": "next start"
   },
   "dependencies": {

--- a/templates/template-next-tailwind-counter/package.json
+++ b/templates/template-next-tailwind-counter/package.json
@@ -12,6 +12,12 @@
     "wallet-ui"
   ],
   "create-solana-dapp": {
+    "instructions": [
+      "To configure the Anchor deployment keypair, run this:",
+      "+{pm} run setup",
+      "Run Anchor commands:",
+      "+{pm} run anchor build | test | localnet | deploy"
+    ],
     "rename": {
       "counter": {
         "to": "{{name}}",
@@ -44,6 +50,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "next lint",
+    "setup": "npm run anchor keys sync && npm run codama:js",
     "start": "next start"
   },
   "dependencies": {

--- a/templates/template-react-vite-tailwind-basic/package.json
+++ b/templates/template-react-vite-tailwind-basic/package.json
@@ -12,6 +12,12 @@
     "wallet-ui"
   ],
   "create-solana-dapp": {
+    "instructions": [
+      "To configure the Anchor deployment keypair, run this:",
+      "+{pm} run setup",
+      "Run Anchor commands:",
+      "+{pm} run anchor build | test | localnet | deploy"
+    ],
     "rename": {
       "basic": {
         "to": "{{name}}",
@@ -43,7 +49,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "setup": "npm run anchor keys sync && npm run codama:js"
   },
   "dependencies": {
     "@codama/cli": "^1.1.1",

--- a/templates/template-react-vite-tailwind-counter/package.json
+++ b/templates/template-react-vite-tailwind-counter/package.json
@@ -12,6 +12,12 @@
     "wallet-ui"
   ],
   "create-solana-dapp": {
+    "instructions": [
+      "To configure the Anchor deployment keypair, run this:",
+      "+{pm} run setup",
+      "Run Anchor commands:",
+      "+{pm} run anchor build | test | localnet | deploy"
+    ],
     "rename": {
       "counter": {
         "to": "{{name}}",
@@ -43,7 +49,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "setup": "npm run anchor keys sync && npm run codama:js"
   },
   "dependencies": {
     "@codama/cli": "^1.1.1",


### PR DESCRIPTION
In order to get a working project the user will need to run `pnpm run anchor keys sync` and `pnpm run codama:js`.

This PR adds a shortcut called `setup` and instructions to `npm run setup` after cloning.