### PR TITLE
refactor: codama usage and packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,15 +825,6 @@ importers:
 
   templates/template-next-tailwind-basic:
     dependencies:
-      '@codama/cli':
-        specifier: ^1.1.2
-        version: 1.1.2(chokidar@3.6.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@codama/nodes-from-anchor':
-        specifier: ^1.2.1
-        version: 1.2.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@codama/renderers-js':
-        specifier: ^1.2.14
-        version: 1.2.14(chokidar@3.6.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -898,6 +889,9 @@ importers:
         specifier: ^1.3.5
         version: 1.3.5
     devDependencies:
+      '@codama/cli':
+        specifier: ^1.1.2
+        version: 1.1.2(chokidar@3.6.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@eslint/eslintrc':
         specifier: ^3.3.1
         version: 3.3.1
@@ -943,15 +937,6 @@ importers:
 
   templates/template-next-tailwind-counter:
     dependencies:
-      '@codama/cli':
-        specifier: ^1.1.2
-        version: 1.1.2(chokidar@3.6.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@codama/nodes-from-anchor':
-        specifier: ^1.2.1
-        version: 1.2.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@codama/renderers-js':
-        specifier: ^1.2.14
-        version: 1.2.14(chokidar@3.6.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1019,6 +1004,9 @@ importers:
         specifier: ^1.3.5
         version: 1.3.5
     devDependencies:
+      '@codama/cli':
+        specifier: ^1.1.2
+        version: 1.1.2(chokidar@3.6.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@eslint/eslintrc':
         specifier: ^3.3.1
         version: 3.3.1
@@ -1292,9 +1280,6 @@ importers:
 
   templates/template-react-vite-tailwind-basic:
     dependencies:
-      '@codama/cli':
-        specifier: ^1.1.2
-        version: 1.1.2(chokidar@3.6.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1365,6 +1350,9 @@ importers:
         specifier: ^8.18.3
         version: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
+      '@codama/cli':
+        specifier: ^1.1.2
+        version: 1.1.2(chokidar@3.6.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@eslint/js':
         specifier: ^9.30.1
         version: 9.30.1
@@ -1419,9 +1407,6 @@ importers:
 
   templates/template-react-vite-tailwind-counter:
     dependencies:
-      '@codama/cli':
-        specifier: ^1.1.2
-        version: 1.1.2(chokidar@3.6.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1492,6 +1477,9 @@ importers:
         specifier: ^8.18.3
         version: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
+      '@codama/cli':
+        specifier: ^1.1.2
+        version: 1.1.2(chokidar@3.6.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@eslint/js':
         specifier: ^9.30.1
         version: 9.30.1

--- a/templates/template-next-tailwind-basic/package.json
+++ b/templates/template-next-tailwind-basic/package.json
@@ -40,11 +40,10 @@
   "scripts": {
     "anchor": "cd anchor && anchor",
     "anchor-build": "cd anchor && anchor build",
-    "anchor-client": "esrun ./anchor/src/generate-client.ts",
     "anchor-localnet": "cd anchor && anchor localnet",
     "anchor-test": "cd anchor && anchor test",
     "build": "next build",
-    "codama:js": "codama run -c ./anchor/codama.js js",
+    "codama:js": "codama run js -c ./anchor/codama.js",
     "ci": "npm run build && npm run lint && npm run format:check && npm run codama:js",
     "dev": "next dev --turbopack",
     "format": "prettier --write .",
@@ -54,9 +53,6 @@
     "start": "next start"
   },
   "dependencies": {
-    "@codama/cli": "^1.1.2",
-    "@codama/nodes-from-anchor": "^1.2.1",
-    "@codama/renderers-js": "^1.2.14",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
@@ -80,6 +76,7 @@
     "tw-animate-css": "^1.3.5"
   },
   "devDependencies": {
+    "@codama/cli": "^1.1.2",
     "@eslint/eslintrc": "^3.3.1",
     "@tailwindcss/postcss": "^4.1.11",
     "@types/jest": "^30.0.0",

--- a/templates/template-next-tailwind-counter/package.json
+++ b/templates/template-next-tailwind-counter/package.json
@@ -40,11 +40,10 @@
   "scripts": {
     "anchor": "cd anchor && anchor",
     "anchor-build": "cd anchor && anchor build",
-    "anchor-client": "esrun ./anchor/src/generate-client.ts",
     "anchor-localnet": "cd anchor && anchor localnet",
     "anchor-test": "cd anchor && anchor test",
     "build": "next build",
-    "codama:js": "codama run -c ./anchor/codama.js js",
+    "codama:js": "codama run js -c ./anchor/codama.js",
     "ci": "npm run build && npm run lint && npm run format:check && npm run codama:js",
     "dev": "next dev --turbopack",
     "format": "prettier --write .",
@@ -54,9 +53,6 @@
     "start": "next start"
   },
   "dependencies": {
-    "@codama/cli": "^1.1.2",
-    "@codama/nodes-from-anchor": "^1.2.1",
-    "@codama/renderers-js": "^1.2.14",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
@@ -81,6 +77,7 @@
     "tw-animate-css": "^1.3.5"
   },
   "devDependencies": {
+    "@codama/cli": "^1.1.2",
     "@eslint/eslintrc": "^3.3.1",
     "@tailwindcss/postcss": "^4.1.11",
     "@types/jest": "^30.0.0",

--- a/templates/template-react-vite-tailwind-basic/package.json
+++ b/templates/template-react-vite-tailwind-basic/package.json
@@ -39,11 +39,10 @@
   "scripts": {
     "anchor": "cd anchor && anchor",
     "anchor-build": "cd anchor && anchor build",
-    "anchor-client": "esrun ./anchor/src/generate-client.ts",
     "anchor-localnet": "cd anchor && anchor localnet",
     "anchor-test": "cd anchor && anchor test",
     "build": "tsc -b && vite build",
-    "codama:js": "codama run -c ./anchor/codama.js js",
+    "codama:js": "codama run js -c ./anchor/codama.js",
     "ci": "npm run build && npm run lint && npm run format:check",
     "dev": "vite",
     "format": "prettier --write .",
@@ -53,7 +52,6 @@
     "setup": "npm run anchor keys sync && npm run codama:js"
   },
   "dependencies": {
-    "@codama/cli": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
@@ -79,6 +77,7 @@
     "ws": "^8.18.3"
   },
   "devDependencies": {
+    "@codama/cli": "^1.1.2",
     "@eslint/js": "^9.30.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.12",

--- a/templates/template-react-vite-tailwind-counter/package.json
+++ b/templates/template-react-vite-tailwind-counter/package.json
@@ -39,11 +39,10 @@
   "scripts": {
     "anchor": "cd anchor && anchor",
     "anchor-build": "cd anchor && anchor build",
-    "anchor-client": "esrun ./anchor/src/generate-client.ts",
     "anchor-localnet": "cd anchor && anchor localnet",
     "anchor-test": "cd anchor && anchor test",
     "build": "tsc -b && vite build",
-    "codama:js": "codama run -c ./anchor/codama.js js",
+    "codama:js": "codama run js -c ./anchor/codama.js",
     "ci": "npm run build && npm run lint && npm run format:check",
     "dev": "vite",
     "format": "prettier --write .",
@@ -53,7 +52,6 @@
     "setup": "npm run anchor keys sync && npm run codama:js"
   },
   "dependencies": {
-    "@codama/cli": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
@@ -79,6 +77,7 @@
     "ws": "^8.18.3"
   },
   "devDependencies": {
+    "@codama/cli": "^1.1.2",
     "@eslint/js": "^9.30.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.12",


### PR DESCRIPTION
- removed the unused codama packages
- removed the unused `anchor-client` script (since `codama:js` should be used now)
- corrected `@codama/cli` to be a dev dep
- refactored `codama run` command for readability