### PR TITLE
refactor: simplify gitignore

### DIFF
--- a/legacy/legacy-next-tailwind-basic/anchor/.gitignore
+++ b/legacy/legacy-next-tailwind-basic/anchor/.gitignore
@@ -1,11 +1,8 @@
 .anchor
 .DS_Store
-target/debug
-target/deploy
-target/release
-target/sbf-solana-solana
-target/test-ledger
-target/.rustc_info.json
+target
+!target/idl/
+!target/types/
 **/*.rs.bk
 node_modules
 test-ledger

--- a/legacy/legacy-next-tailwind-counter/anchor/.gitignore
+++ b/legacy/legacy-next-tailwind-counter/anchor/.gitignore
@@ -1,11 +1,8 @@
 .anchor
 .DS_Store
-target/debug
-target/deploy
-target/release
-target/sbf-solana-solana
-target/test-ledger
-target/.rustc_info.json
+target
+!target/idl/
+!target/types/
 **/*.rs.bk
 node_modules
 test-ledger

--- a/legacy/legacy-react-vite-tailwind-counter/anchor/.gitignore
+++ b/legacy/legacy-react-vite-tailwind-counter/anchor/.gitignore
@@ -1,11 +1,8 @@
 .anchor
 .DS_Store
-target/debug
-target/deploy
-target/release
-target/sbf-solana-solana
-target/test-ledger
-target/.rustc_info.json
+target
+!target/idl/
+!target/types/
 **/*.rs.bk
 node_modules
 test-ledger

--- a/templates/template-next-tailwind-basic/anchor/.gitignore
+++ b/templates/template-next-tailwind-basic/anchor/.gitignore
@@ -1,11 +1,8 @@
 .anchor
 .DS_Store
-target/debug
-target/deploy
-target/release
-target/sbf-solana-solana
-target/test-ledger
-target/.rustc_info.json
+target
+!target/idl/
+!target/types/
 **/*.rs.bk
 node_modules
 test-ledger

--- a/templates/template-next-tailwind-counter/anchor/.gitignore
+++ b/templates/template-next-tailwind-counter/anchor/.gitignore
@@ -1,11 +1,8 @@
 .anchor
 .DS_Store
-target/debug
-target/deploy
-target/release
-target/sbf-solana-solana
-target/test-ledger
-target/.rustc_info.json
+target
+!target/idl/
+!target/types/
 **/*.rs.bk
 node_modules
 test-ledger

--- a/templates/template-react-vite-tailwind-basic/anchor/.gitignore
+++ b/templates/template-react-vite-tailwind-basic/anchor/.gitignore
@@ -1,11 +1,8 @@
 .anchor
 .DS_Store
-target/debug
-target/deploy
-target/release
-target/sbf-solana-solana
-target/test-ledger
-target/.rustc_info.json
+target
+!target/idl/
+!target/types/
 **/*.rs.bk
 node_modules
 test-ledger

--- a/templates/template-react-vite-tailwind-counter/anchor/.gitignore
+++ b/templates/template-react-vite-tailwind-counter/anchor/.gitignore
@@ -1,11 +1,8 @@
 .anchor
 .DS_Store
-target/debug
-target/deploy
-target/release
-target/sbf-solana-solana
-target/test-ledger
-target/.rustc_info.json
+target
+!target/idl/
+!target/types/
 **/*.rs.bk
 node_modules
 test-ledger


### PR DESCRIPTION
simplify the solana program specific gitignore files to commit the generated idl and types, but nothing else in the `target` dir. this makes it so we do not need to maintain a specific list of dirs in the gitignore