### PR TITLE
refactor: use gill createTransaction

### DIFF
--- a/templates/template-next-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-next-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,32 +1,21 @@
 import { useWalletUi } from '@wallet-ui/react'
-import {
-  appendTransactionMessageInstruction,
-  assertIsTransactionMessageWithSingleSendingSigner,
-  createTransactionMessage,
-  getBase58Decoder,
-  IInstruction,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signAndSendTransactionMessageWithSigners,
-  TransactionSendingSigner,
-} from 'gill'
+import type { IInstruction, TransactionSendingSigner } from 'gill'
+import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
 
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
   return async (ix: IInstruction, signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
-    const message = pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-      (tx) => appendTransactionMessageInstruction(ix, tx),
-    )
 
-    assertIsTransactionMessageWithSingleSendingSigner(message)
+    const transaction = createTransaction({
+      feePayer: signer,
+      version: 0,
+      latestBlockhash,
+      instructions: [ix],
+    })
 
-    const signature = await signAndSendTransactionMessageWithSigners(message)
+    const signature = await signAndSendTransactionMessageWithSigners(transaction)
 
     return getBase58Decoder().decode(signature)
   }

--- a/templates/template-next-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-next-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,32 +1,21 @@
 import { useWalletUi } from '@wallet-ui/react'
-import {
-  appendTransactionMessageInstruction,
-  assertIsTransactionMessageWithSingleSendingSigner,
-  createTransactionMessage,
-  getBase58Decoder,
-  IInstruction,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signAndSendTransactionMessageWithSigners,
-  TransactionSendingSigner,
-} from 'gill'
+import type { IInstruction, TransactionSendingSigner } from 'gill'
+import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
 
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
   return async (ix: IInstruction, signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
-    const message = pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-      (tx) => appendTransactionMessageInstruction(ix, tx),
-    )
 
-    assertIsTransactionMessageWithSingleSendingSigner(message)
+    const transaction = createTransaction({
+      feePayer: signer,
+      version: 0,
+      latestBlockhash,
+      instructions: [ix],
+    })
 
-    const signature = await signAndSendTransactionMessageWithSigners(message)
+    const signature = await signAndSendTransactionMessageWithSigners(transaction)
 
     return getBase58Decoder().decode(signature)
   }

--- a/templates/template-next-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-next-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,32 +1,21 @@
 import { useWalletUi } from '@wallet-ui/react'
-import {
-  appendTransactionMessageInstruction,
-  assertIsTransactionMessageWithSingleSendingSigner,
-  createTransactionMessage,
-  getBase58Decoder,
-  IInstruction,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signAndSendTransactionMessageWithSigners,
-  TransactionSendingSigner,
-} from 'gill'
+import type { IInstruction, TransactionSendingSigner } from 'gill'
+import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
 
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
   return async (ix: IInstruction, signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
-    const message = pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-      (tx) => appendTransactionMessageInstruction(ix, tx),
-    )
 
-    assertIsTransactionMessageWithSingleSendingSigner(message)
+    const transaction = createTransaction({
+      feePayer: signer,
+      version: 0,
+      latestBlockhash,
+      instructions: [ix],
+    })
 
-    const signature = await signAndSendTransactionMessageWithSigners(message)
+    const signature = await signAndSendTransactionMessageWithSigners(transaction)
 
     return getBase58Decoder().decode(signature)
   }

--- a/templates/template-react-vite-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-react-vite-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,32 +1,21 @@
 import { useWalletUi } from '@wallet-ui/react'
-import {
-  appendTransactionMessageInstruction,
-  assertIsTransactionMessageWithSingleSendingSigner,
-  createTransactionMessage,
-  getBase58Decoder,
-  IInstruction,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signAndSendTransactionMessageWithSigners,
-  TransactionSendingSigner,
-} from 'gill'
+import type { IInstruction, TransactionSendingSigner } from 'gill'
+import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
 
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
   return async (ix: IInstruction, signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
-    const message = pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-      (tx) => appendTransactionMessageInstruction(ix, tx),
-    )
 
-    assertIsTransactionMessageWithSingleSendingSigner(message)
+    const transaction = createTransaction({
+      feePayer: signer,
+      version: 0,
+      latestBlockhash,
+      instructions: [ix],
+    })
 
-    const signature = await signAndSendTransactionMessageWithSigners(message)
+    const signature = await signAndSendTransactionMessageWithSigners(transaction)
 
     return getBase58Decoder().decode(signature)
   }

--- a/templates/template-react-vite-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-react-vite-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,32 +1,21 @@
 import { useWalletUi } from '@wallet-ui/react'
-import {
-  appendTransactionMessageInstruction,
-  assertIsTransactionMessageWithSingleSendingSigner,
-  createTransactionMessage,
-  getBase58Decoder,
-  IInstruction,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signAndSendTransactionMessageWithSigners,
-  TransactionSendingSigner,
-} from 'gill'
+import type { IInstruction, TransactionSendingSigner } from 'gill'
+import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
 
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
   return async (ix: IInstruction, signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
-    const message = pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-      (tx) => appendTransactionMessageInstruction(ix, tx),
-    )
 
-    assertIsTransactionMessageWithSingleSendingSigner(message)
+    const transaction = createTransaction({
+      feePayer: signer,
+      version: 0,
+      latestBlockhash,
+      instructions: [ix],
+    })
 
-    const signature = await signAndSendTransactionMessageWithSigners(message)
+    const signature = await signAndSendTransactionMessageWithSigners(transaction)
 
     return getBase58Decoder().decode(signature)
   }

--- a/templates/template-react-vite-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-react-vite-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,32 +1,21 @@
 import { useWalletUi } from '@wallet-ui/react'
-import {
-  appendTransactionMessageInstruction,
-  assertIsTransactionMessageWithSingleSendingSigner,
-  createTransactionMessage,
-  getBase58Decoder,
-  IInstruction,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signAndSendTransactionMessageWithSigners,
-  TransactionSendingSigner,
-} from 'gill'
+import type { IInstruction, TransactionSendingSigner } from 'gill'
+import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
 
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
   return async (ix: IInstruction, signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
-    const message = pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-      (tx) => appendTransactionMessageInstruction(ix, tx),
-    )
 
-    assertIsTransactionMessageWithSingleSendingSigner(message)
+    const transaction = createTransaction({
+      feePayer: signer,
+      version: 0,
+      latestBlockhash,
+      instructions: [ix],
+    })
 
-    const signature = await signAndSendTransactionMessageWithSigners(message)
+    const signature = await signAndSendTransactionMessageWithSigners(transaction)
 
     return getBase58Decoder().decode(signature)
   }


### PR DESCRIPTION
simplify the `useWalletTransactionSignAndSend` hook to use gill's `createTransaction` function

edit: the `signAndSendTransactionMessageWithSigners` function already performs the `assertIsTransactionMessageWithSingleSendingSigner` assertion. see code [here](https://github.com/anza-xyz/kit/blob/302043e140d345fee470bac4c2fa3d1d9695170b/packages/signers/src/sign-transaction.ts#L175-L202)